### PR TITLE
React 0.14

### DIFF
--- a/examples/index.cjsx
+++ b/examples/index.cjsx
@@ -1,4 +1,5 @@
 React = require('react')
+ReactDOM = require('react-dom')
 Examples = require './examples'
 
-React.render(<Examples />, document.body)
+ReactDOM.render(<Examples />, document.body)

--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
     "faker": "^2.1.3",
     "gulp": "^3.8.11",
     "node-libs-browser": "^0.5.0",
-    "react": "^0.13.3",
+    "react": "^0.14.0",
+    "react-dom": "^0.14.0",
     "react-hot-loader": "^1.2.7",
     "react-simple-table": "^0.6.0",
     "style-loader": "^0.12.2",
@@ -34,7 +35,8 @@
   "license": "MIT",
   "main": "dist/index.js",
   "peerDependencies": {
-    "react": "*"
+    "react": "*",
+    "react-dom": "*"
   },
   "repository": {
     "type": "git",

--- a/src/index.cjsx
+++ b/src/index.cjsx
@@ -1,4 +1,5 @@
 React = require 'react'
+ReactDOM = require 'react-dom'
 d3 = require 'd3'
 
 module.exports = React.createClass
@@ -41,7 +42,7 @@ module.exports = React.createClass
     else
       height = @props.height
 
-    chart = d3.select(@getDOMNode())
+    chart = d3.select(ReactDOM.findDOMNode(@))
         .attr("width", @props.width)
         .attr("height", height)
 


### PR DESCRIPTION
- use ReactDOM.findDOMNode(c) instead of c.getDOMNode()
- use ReactDOM.render instead of React.render